### PR TITLE
Performance & correctness fixes for classic and differential evolution fitting

### DIFF
--- a/hspipy/core/hsp_estimator.py
+++ b/hspipy/core/hsp_estimator.py
@@ -69,7 +69,7 @@ class HSPEstimator(TransformerMixin, BaseEstimator):
         "de_recombination": [Interval(Real, 0, 1, closed="both")],
         "de_init": [StrOptions({"latinhypercube"})],  # Add all valid options
         "de_atol": [Interval(Real, 0, None, closed="left")],
-        "de_updating": [StrOptions({"immediate"})],  # Add all valid options
+        "de_updating": [StrOptions({"immediate", "deferred"})],
         "de_workers": [Interval(Integral, 1, None, closed="left")],
         "min_options": [None, dict],
     }
@@ -110,14 +110,14 @@ class HSPEstimator(TransformerMixin, BaseEstimator):
         # Differential Evolution params
         de_bounds=None,
         de_strategy='best1bin',
-        de_maxiter=2000,
+        de_maxiter=1000,
         de_popsize=15,
         de_tol=1e-6,
         de_mutation=0.7,
         de_recombination=0.4,
         de_init='latinhypercube',
         de_atol=0,
-        de_updating='immediate',
+        de_updating='deferred',
         de_workers=1,
         # Minimize params
         min_options=None,
@@ -496,14 +496,20 @@ class HSPEstimator(TransformerMixin, BaseEstimator):
         X_good = X[y == 1, :3]
         if X_good.shape[0] < self.n_spheres:
             raise ValueError("Not enough inside solvents to form the required number of spheres.")
-        
+
         loss_func = self._get_loss_function()
         bounds = self._get_bounds()
         x0 = self._get_initial_guess(X_good)
 
         def objective(array):
             return loss_func(array, X, y)
-        
+
+        # vectorized=True lets scipy pass the entire population (n_params, S) to
+        # the objective at once. The loss functions handle the batch dimension via
+        # ndim dispatch, replacing ~S Python call overhead with a single numpy
+        # operation. scipy requires updating='deferred' with vectorized=True, and
+        # raises ValueError if workers > 1 is combined with vectorized, so we
+        # clamp workers to 1 here.
         options = {
             'bounds': bounds,
             'strategy': self.de_strategy,
@@ -514,10 +520,11 @@ class HSPEstimator(TransformerMixin, BaseEstimator):
             'recombination': self.de_recombination,
             'init': self.de_init,
             'atol': self.de_atol,
-            'updating': self.de_updating,
-            'workers': self.de_workers,
+            'updating': 'deferred',
+            'workers': 1,
             'x0': x0,
-            }
+            'vectorized': True,
+        }
 
         result = differential_evolution(objective, **options)
 

--- a/hspipy/core/hsp_estimator.py
+++ b/hspipy/core/hsp_estimator.py
@@ -213,69 +213,103 @@ class HSPEstimator(TransformerMixin, BaseEstimator):
             raise ValueError("DATAFIT computation only implemented for 1 or 2 spheres.")
      
     def _classic_fit(self, X, y):
-        """Classic fitting algorithm for single sphere."""
+        """Classic fitting algorithm for single sphere (vectorized)."""
         X = np.asarray(X, dtype=float)
         if np.sum(y == 1) == 0:
             raise ValueError("No good solvents found for classic fit.")
-        
+
         nfev = 0
         nit_total = 0
+        inside = (y == 1)
+        outside = ~inside
 
-        def datafit(dist, R):
+        def best_radius_vec(dist):
+            """Vectorized radius search: evaluates all candidates in one numpy pass."""
             nonlocal nfev
-            nfev += 1
-            return compute_datafit(dist, R, y)
+            unique_dists = np.unique(dist)
+            candidates = np.r_[
+                max(unique_dists[0] - 1e-6, 0.0),
+                unique_dists,
+                unique_dists + 1e-6,
+                unique_dists[-1] + 1.0,
+            ]  # (n_cand,)
+            nfev += len(candidates)
 
-        def best_radius(dist):
-            dists = np.unique(dist)
-            candidates = np.r_[max(dists.min() - 1e-6, 0.0), dists, dists + 1e-6, dists.max() + 1.0]
-            best_df = -np.inf
-            best_R = None
-            for R in candidates:
-                df = datafit(dist, R)
-                if df > best_df or (np.isclose(df, best_df) and (best_R is None or R < best_R)):
-                    best_df = df
-                    best_R = R
+            # delta[i, j] = dist[i] - candidates[j],  shape (n_samples, n_cand)
+            delta = dist[:, None] - candidates[None, :]
+            fitness = np.ones_like(delta)
+
+            # good solvent outside sphere
+            good_out = inside[:, None] & (delta > 0)
+            fitness[good_out] = np.exp(-delta[good_out])
+
+            # bad solvent inside sphere
+            bad_in = outside[:, None] & (delta < 0)
+            fitness[bad_in] = np.exp(delta[bad_in])
+
+            fitness = np.maximum(fitness, 1e-12)
+            datafit_all = np.exp(np.mean(np.log(fitness), axis=0))  # (n_cand,)
+
+            best_df = float(datafit_all.max())
+            tied = np.abs(datafit_all - best_df) < 1e-9
+            best_R = float(candidates[tied].min())
             return best_R, best_df
 
         # Start at mean of good solvents
-        center = X[y == 1, :3].mean(axis=0)
+        center = X[inside].mean(axis=0)
         dist = hansen_distance(X, center)
-        best_R, best_df = best_radius(dist)
+        best_R, best_df = best_radius_vec(dist)
         best_center = center.copy()
 
-        # Edge lengths 1.0 → 0.3 → 0.1; use ±half-edge offsets for corners
+        signs = np.array([[sx, sy, sz]
+                          for sx in (-1.0, 1.0)
+                          for sy in (-1.0, 1.0)
+                          for sz in (-1.0, 1.0)])  # (8, 3)
+
+        # Strict-improvement hill-climb: only move when df strictly increases.
+        # R tie-breaking is intentionally excluded from the movement criterion —
+        # mixing it in creates a large plateau traversal that never terminates
+        # on some datasets. The minimum radius for the final center is resolved
+        # once by best_radius_vec after convergence.
+        tol = 1e-9
         for edge in (1.0, 0.3, 0.1):
             h = 0.5 * edge
             improved = True
-            signs = np.array([[sx, sy, sz] for sx in (-1.0, 1.0) for sy in (-1.0, 1.0) for sz in (-1.0, 1.0)])
             iter_count = 0
             while improved:
                 improved = False
                 iter_count += 1
-                corners = best_center[None, :] + h * signs
-                for c in corners:
-                    dist_c = hansen_distance(X, c)
-                    R_c, df_c = best_radius(dist_c)
-                    if df_c > best_df or (np.isclose(df_c, best_df) and R_c < best_R):
+                corners = best_center[None, :] + h * signs  # (8, 3)
+
+                # All 8 corner distances in one broadcast: (n_samples, 8)
+                d = X[:, None, :] - corners[None, :, :]
+                dist_all = np.sqrt(4.0 * d[..., 0]**2 + d[..., 1]**2 + d[..., 2]**2)
+
+                for k in range(8):
+                    R_c, df_c = best_radius_vec(dist_all[:, k])
+                    if df_c > best_df + tol:
                         best_df = df_c
                         best_R = R_c
-                        best_center = c
+                        best_center = corners[k]
                         improved = True
             nit_total += iter_count
+
+        # Resolve minimum radius for the converged center
+        dist = hansen_distance(X, best_center)
+        best_R, best_df = best_radius_vec(dist)
 
         self.hsp_ = np.array([[best_center[0], best_center[1], best_center[2], best_R]])
         self.error_ = 1.0 - best_df
         self.datafit_ = best_df
         self.optimization_result_ = OptimizeResult({
-            'method': 'classic', 
+            'method': 'classic',
             'fun': float(self.error_),
             'x': self.hsp_.flatten().tolist(),
             'success': True,
             'message': f'classic finished, datafit={best_df:.6g}',
             'nit': int(nit_total),
             'nfev': int(nfev),
-            })
+        })
         return self
   
     def _classic_two_fit(self, X, y):

--- a/hspipy/core/hsp_estimator.py
+++ b/hspipy/core/hsp_estimator.py
@@ -313,130 +313,149 @@ class HSPEstimator(TransformerMixin, BaseEstimator):
         return self
   
     def _classic_two_fit(self, X, y):
-        """Classic HSP fit restricted to exactly 2 spheres."""
+        """Classic HSP fit restricted to exactly 2 spheres (vectorized)."""
         if self.n_spheres != 2:
             raise ValueError("classic_two requires n_spheres == 2.")
         X = np.asarray(X, dtype=float)
-
         if np.sum(y == 1) == 0:
             raise ValueError("No good solvents found for classic_two.")
 
         nfev = 0
         nit_total = 0
+        inside = (y == 1)
+        outside = ~inside
 
-        # --- Constraint-aware datafit ---
-        def combine_datafit(dists_list, radii, centers):
+        def best_radius_for_sphere_vec(candidate_center, dist_j, dist_k, R_k, center_k):
+            """Vectorized radius search for one sphere, keeping the other fixed.
+
+            candidate_center is passed explicitly so the containment constraint
+            uses the new position rather than the stale centers list.
+            """
             nonlocal nfev
-            nfev += 1
-            distances = np.stack(dists_list, axis=1)  # (n_samples, 2)
-            R = np.asarray(radii).reshape((1, 2))
-            df = compute_datafit(distances, R, y)
+            unique_dists = np.unique(dist_j)
+            candidates = np.r_[
+                max(unique_dists[0] - 1e-6, 0.0),
+                unique_dists,
+                unique_dists + 1e-6,
+                unique_dists[-1] + 1.0,
+            ]
+            nfev += len(candidates)
 
-            # Apply constraints as penalties
-            penalty = 0.0
-            # (1) Sphere containment
-            d = hansen_center_distance(centers[0], centers[1])
-            if d + min(radii) <= max(radii) + 1e-8:
-                penalty += 1000.0
-            # (2) Each sphere must contain at least two "good"
-            inside = (y == 1)
-            if np.any(inside):
-               # Count how many good solvents each sphere contains
-                good_counts = np.sum(inside[:, None] & (distances <= R), axis=0)
-                # Require at least 2 per sphere
-                if np.any(good_counts < 2):
-                    penalty += 1000.0
-            else:
-                penalty += 1000.0
+            delta_j = dist_j[:, None] - candidates[None, :]  # (n_samples, n_cand)
+            delta_k = dist_k - R_k  # (n_samples,)
 
-            # (3) Minimum radius to avoid collapse
-            min_radius = 1
-            if np.any(np.asarray(radii) < min_radius):
-                penalty += 1000.0
+            # Per-sphere fitness
+            fit_j = np.ones_like(delta_j)
+            g_out_j = inside[:, None] & (delta_j > 0)
+            fit_j[g_out_j] = np.exp(-delta_j[g_out_j])
+            b_in_j = outside[:, None] & (delta_j < 0)
+            fit_j[b_in_j] = np.exp(delta_j[b_in_j])
 
-            return df - penalty
+            fit_k = np.ones(len(y))
+            g_out_k = inside & (delta_k > 0)
+            fit_k[g_out_k] = np.exp(-delta_k[g_out_k])
+            b_in_k = outside & (delta_k < 0)
+            fit_k[b_in_k] = np.exp(delta_k[b_in_k])
 
-        def best_radius_for_sphere(dist_j, dists_list, radii, j, centers):
-            # scan candidate radii for sphere j keeping others fixed
-            dists = np.unique(dist_j)
-            candidates = np.r_[max(dists.min() - 1e-6, 0.0),
-                            dists,
-                            dists + 1e-6,
-                            dists.max() + 1.0]
-            best_df = -np.inf
-            best_R = radii[j]
-            for R in candidates:
-                candidate_r = list(radii)
-                candidate_r[j] = R
-                df = combine_datafit(dists_list, candidate_r, centers)
-                if df > best_df or (np.isclose(df, best_df) and R < best_R):
-                    best_df = df
-                    best_R = R
-            return best_R, best_df
+            # Combined fitness: worst across both spheres, then override correct good
+            fitness = np.minimum(fit_j, fit_k[:, None])
+            correct = (inside[:, None] & (delta_j <= 0)) | (inside & (dist_k <= R_k))[:, None]
+            fitness[correct] = 1.0
+            fitness = np.maximum(fitness, 1e-12)
+            datafit_all = np.exp(np.mean(np.log(fitness), axis=0))  # (n_cand,)
 
-        # --- Initialization: farthest pair among good solvents ---
+            # Constraint penalties (vectorized over candidates)
+            cd = hansen_center_distance(candidate_center, center_k)
+            min_r = np.minimum(candidates, R_k)
+            max_r = np.maximum(candidates, R_k)
+            penalty = np.zeros(len(candidates))
+            penalty[(cd + min_r) <= (max_r + 1e-8)] += 1000.0
+            good_j = np.sum(inside[:, None] & (delta_j <= 0), axis=0)
+            good_k = int(np.sum(inside & (dist_k <= R_k)))
+            penalty[(good_j < 2) | (good_k < 2)] += 1000.0
+            penalty[candidates < 1] += 1000.0
+
+            scored = datafit_all - penalty
+            best_scored = float(scored.max())
+            tied = np.abs(scored - best_scored) < 1e-9
+            best_R = float(candidates[tied].min())
+            return best_R, best_scored
+
+        # --- Initialization ---
         X_good = X[y == 1, :3]
         if X_good.shape[0] < 2:
             raise ValueError("Not enough good solvents to initialize 2 spheres.")
 
-        initial_guess = self._get_initial_guess(X_good)  # shape (8,)
-        centers = [initial_guess[i*4:i*4+3].copy() for i in range(2)]
-
+        initial_guess = self._get_initial_guess(X_good)
+        centers = [initial_guess[i * 4:i * 4 + 3].copy() for i in range(2)]
         dists_list = [hansen_distance(X, c) for c in centers]
-        radii = [0.5, 0.5]
+        radii = [1.0, 1.0]
+        best_df = -np.inf
 
-        # Initial datafit
-        best_df = combine_datafit(dists_list, radii, centers)
+        signs = np.array([[sx, sy, sz]
+                          for sx in (-1.0, 1.0)
+                          for sy in (-1.0, 1.0)
+                          for sz in (-1.0, 1.0)])  # (8, 3)
 
-        # --- Classic cube schedule ---
+        # Strict-improvement hill-climb: same rationale as _classic_fit.
+        # R tie-breaking removed from both the inner candidate selection and
+        # the outer movement condition to prevent plateau traversal.
+        tol = 1e-9
         for edge in (1.0, 0.3, 0.1):
             h = 0.5 * edge
             improved = True
-            max_iter = 1000
             iter_count = 0
-            tol = 1e-6
-            while improved and iter_count < max_iter:
+            while improved:
                 improved = False
-                signs = np.array([[sx, sy, sz] for sx in (-1.0, 1.0)
-                                                for sy in (-1.0, 1.0)
-                                                for sz in (-1.0, 1.0)])
                 iter_count += 1
                 for j in range(2):
-                    best_local = None
+                    k = 1 - j
                     best_local_df = best_df
-                    best_local_R = radii[j]
-                    for s in signs:
-                        c = centers[j] + h * s
-                        dist_j = hansen_distance(X, c)
-                        cand_dists = list(dists_list)
-                        cand_dists[j] = dist_j
-                        Rj, dfj = best_radius_for_sphere(dist_j, cand_dists, radii, j, centers)
-                        cand_centers = list(centers)
-                        cand_centers[j] = c
-                        cand_radii = list(radii)
-                        cand_radii[j] = Rj
-                        df_total = combine_datafit(cand_dists, cand_radii, cand_centers)
-                        if df_total > best_local_df or (np.isclose(df_total, best_local_df) and Rj < best_local_R):
-                            best_local_df = df_total
-                            best_local_R = Rj
-                            best_local = (cand_dists, cand_centers, cand_radii)
-                    if best_local is not None and (best_local_df > best_df + tol or
-                                                (np.isclose(best_local_df, best_df) and best_local_R < radii[j])):
-                        dists_list, centers, radii = best_local
+                    best_local = None
+
+                    corners = centers[j][None, :] + h * signs  # (8, 3)
+                    d = X[:, None, :] - corners[None, :, :]
+                    dist_j_all = np.sqrt(4.0 * d[..., 0]**2 + d[..., 1]**2 + d[..., 2]**2)
+
+                    for idx in range(8):
+                        Rj, dfj = best_radius_for_sphere_vec(
+                            corners[idx], dist_j_all[:, idx],
+                            dists_list[k], radii[k], centers[k],
+                        )
+                        if dfj > best_local_df + tol:
+                            best_local_df = dfj
+                            best_local = (corners[idx], dist_j_all[:, idx], Rj)
+
+                    if best_local is not None:
+                        c, dist_j, Rj = best_local
+                        centers[j] = c
+                        radii[j] = Rj
+                        dists_list[j] = dist_j
                         best_df = best_local_df
                         improved = True
             nit_total += iter_count
 
+        # Resolve final radii for both spheres after convergence
+        for j in range(2):
+            k = 1 - j
+            radii[j], _ = best_radius_for_sphere_vec(
+                centers[j], dists_list[j], dists_list[k], radii[k], centers[k],
+            )
+
+        # Report unpenalized datafit for the final configuration
+        distances = np.stack(dists_list, axis=1)
+        actual_df = float(compute_datafit(distances, np.array(radii).reshape(1, 2), y))
+
         self.hsp_ = np.array([[centers[i][0], centers[i][1], centers[i][2], radii[i]] for i in range(2)])
-        self.error_ = 1.0 - best_df
-        self.datafit_ = best_df
+        self.error_ = 1.0 - actual_df
+        self.datafit_ = actual_df
         self.optimization_result_ = OptimizeResult({
             'method': 'classic_two',
-            'datafit': best_df,
+            'datafit': actual_df,
             'fun': float(self.error_),
             'x': self.hsp_.flatten().tolist(),
             'success': True,
-            'message': f'classic finished, datafit={best_df:.6g}',
+            'message': f'classic finished, datafit={actual_df:.6g}',
             'nit': int(nit_total),
             'nfev': int(nfev),
         })

--- a/hspipy/core/loss.py
+++ b/hspipy/core/loss.py
@@ -21,7 +21,7 @@ class BaseHSPLoss:
         else:
             m = float(self.size_factor)
             return datafit * np.prod(radii) ** (-1 / m)
-    
+
     def _finalize_output(self, of_value):
         """Convert to minimization or maximization objective."""
         return 1 - float(of_value) if self.minimize else float(of_value)
@@ -29,8 +29,10 @@ class BaseHSPLoss:
 class HSPSingleSphereLoss(BaseHSPLoss):
     """Loss function for fitting a single HSP sphere via optimization."""
 
-    def __call__(self, HSP: NDArray, X: NDArray, y: NDArray) -> float:
+    def __call__(self, HSP: NDArray, X: NDArray, y: NDArray) -> float | NDArray:
         self.y = y
+        if np.ndim(HSP) == 2:
+            return self._batch_call(HSP, X, y)
         D, P, H, R = HSP
         center = np.array([D, P, H])
         dist = hansen_distance(X, center)
@@ -41,56 +43,134 @@ class HSPSingleSphereLoss(BaseHSPLoss):
 
         return self._finalize_output(objective)
 
+    def _batch_call(self, HSP: NDArray, X: NDArray, y: NDArray) -> NDArray:
+        """Evaluate all population members at once.
+
+        Used by scipy's vectorized differential_evolution.
+        HSP: (4, S) → returns (S,)
+        """
+        D, P, H, R = HSP[0], HSP[1], HSP[2], HSP[3]  # each (S,)
+        inside = (y == 1)
+        outside = ~inside
+
+        dD = X[:, None, 0] - D[None, :]
+        dP = X[:, None, 1] - P[None, :]
+        dH = X[:, None, 2] - H[None, :]
+        dist = np.sqrt(4.0 * dD**2 + dP**2 + dH**2)  # (n_samples, S)
+
+        delta = dist - R[None, :]  # (n_samples, S)
+        fitness = np.ones_like(delta)
+        fitness[inside[:, None] & (delta > 0)] = np.exp(-delta[inside[:, None] & (delta > 0)])
+        fitness[outside[:, None] & (delta < 0)] = np.exp(delta[outside[:, None] & (delta < 0)])
+        fitness = np.maximum(fitness, 1e-12)
+        datafit_all = np.exp(np.mean(np.log(fitness), axis=0))  # (S,)
+
+        if self.size_factor is not None:
+            m = len(y) if self.size_factor == "n_solvents" else float(self.size_factor)
+            datafit_all = datafit_all * R ** (-1.0 / m)
+
+        return 1.0 - datafit_all  # (S,)
+
 class HSPDoubleSphereLoss(BaseHSPLoss):
     """Loss function for fitting two HSP spheres via optimization."""
 
-    def __call__(self, HSP: NDArray, X: NDArray, y: NDArray) -> float:
+    def __call__(self, HSP: NDArray, X: NDArray, y: NDArray) -> float | NDArray:
         self.y = y
+        if np.ndim(HSP) == 2:
+            return self._batch_call(HSP, X, y)
         D1, P1, H1, R1 = HSP[0:4]
         D2, P2, H2, R2 = HSP[4:8]
 
         center1 = np.array([D1, P1, H1])
         center2 = np.array([D2, P2, H2])
 
-        # Check constraints; return a large penalty so the optimizer avoids
-        # invalid configurations (one sphere inside the other, or a sphere
-        # with no good solvents).  1e10 is chosen to dominate any realistic
-        # DATAFIT value (which is in [0, 1]) while staying within float64 range.
         if self._violates_constraints(center1, center2, R1, R2, X, y):
             return 1e10
 
-        # Compute distances for all samples to both spheres
         dist1 = hansen_distance(X, center1)
         dist2 = hansen_distance(X, center2)
         distances = np.column_stack([dist1, dist2])
 
-        # Calculate datafit
         datafit = compute_datafit(distances, [R1, R2], y)
-        
+
         objective = self._apply_size_factor(datafit, [R1, R2])
 
         return self._finalize_output(objective)
 
-    
+    def _batch_call(self, HSP: NDArray, X: NDArray, y: NDArray) -> NDArray:
+        """Evaluate all population members at once.
+
+        Used by scipy's vectorized differential_evolution.
+        HSP: (8, S) → returns (S,)
+        """
+        D1, P1, H1, R1 = HSP[0], HSP[1], HSP[2], HSP[3]  # each (S,)
+        D2, P2, H2, R2 = HSP[4], HSP[5], HSP[6], HSP[7]
+
+        inside = (y == 1)
+        outside = ~inside
+
+        def _batch_dist(D, P, H):
+            dD = X[:, None, 0] - D[None, :]
+            dP = X[:, None, 1] - P[None, :]
+            dH = X[:, None, 2] - H[None, :]
+            return np.sqrt(4.0 * dD**2 + dP**2 + dH**2)  # (n_samples, S)
+
+        dist1 = _batch_dist(D1, P1, H1)
+        dist2 = _batch_dist(D2, P2, H2)
+        delta1 = dist1 - R1[None, :]  # (n_samples, S)
+        delta2 = dist2 - R2[None, :]
+
+        fit1 = np.ones_like(delta1)
+        fit1[inside[:, None] & (delta1 > 0)] = np.exp(-delta1[inside[:, None] & (delta1 > 0)])
+        fit1[outside[:, None] & (delta1 < 0)] = np.exp(delta1[outside[:, None] & (delta1 < 0)])
+
+        fit2 = np.ones_like(delta2)
+        fit2[inside[:, None] & (delta2 > 0)] = np.exp(-delta2[inside[:, None] & (delta2 > 0)])
+        fit2[outside[:, None] & (delta2 < 0)] = np.exp(delta2[outside[:, None] & (delta2 < 0)])
+
+        fitness = np.minimum(fit1, fit2)
+        correct = (inside[:, None] & (delta1 <= 0)) | (inside[:, None] & (delta2 <= 0))
+        fitness[correct] = 1.0
+        fitness = np.maximum(fitness, 1e-12)
+        datafit_all = np.exp(np.mean(np.log(fitness), axis=0))  # (S,)
+
+        # Constraint violations → large penalty
+        dD_c = D1 - D2
+        dP_c = P1 - P2
+        dH_c = H1 - H2
+        center_dist = np.sqrt(4.0 * dD_c**2 + dP_c**2 + dH_c**2)  # (S,)
+        containment = (center_dist + np.minimum(R1, R2)) <= (np.maximum(R1, R2) + 1e-8)
+        no_good = (
+            ~np.any(inside[:, None] & (delta1 <= 0), axis=0) |
+            ~np.any(inside[:, None] & (delta2 <= 0), axis=0)
+        )
+
+        result = 1.0 - datafit_all
+
+        if self.size_factor is not None:
+            m = len(y) if self.size_factor == "n_solvents" else float(self.size_factor)
+            result = 1.0 - datafit_all * (R1 * R2) ** (-1.0 / m)
+
+        result[containment | no_good] = 1e10
+        return result
+
     def _violates_constraints(self, center1, center2, R1, R2, X, y):
         """Check if the double sphere configuration violates constraints."""
-        # Prevent one sphere from being completely inside another
         center_distance = hansen_center_distance(center1, center2)
         min_radius, max_radius = min(R1, R2), max(R1, R2)
         if center_distance + min_radius <= max_radius:
             return True
-        
-        # Check if each sphere has at least one good solvent inside
+
         inside_mask = (y == 1)
         X_good = X[inside_mask]
-        
+
         if len(X_good) == 0:
             return True
-            
+
         dist1_good = hansen_distance(X_good, center1)
         dist2_good = hansen_distance(X_good, center2)
-        
+
         sphere1_has_good = np.any(dist1_good <= R1)
         sphere2_has_good = np.any(dist2_good <= R2)
-        
+
         return not (sphere1_has_good and sphere2_has_good)


### PR DESCRIPTION
## Summary

- Fix non-termination in classic (n_spheres=1): the hill-climb loop accepted moves that reduced radius at equal datafit, causing indefinite traversal of flat landscapes on certain datasets. Changed to strict-improvement only (df > best_df + tol); minimum radius for the final center is resolved once after convergence.
- Same fix for classic (n_spheres=2): `_classic_two_fit` had the same R tie-breaking issue in two places. Also fixes a pre-existing bug where the containment constraint was evaluated against the old center position rather than the candidate center.
- Vectorized radius search in both classic methods: replaced the Python loop over ~87 radius candidates per corner with a single `NumPy` broadcast (n_samples × n_candidates), eliminating the per-candidate `compute_datafit` call overhead. Corner distances are now computed for all 8 corners simultaneously.
- Vectorized differential evolution objective: both `HSPSingleSphereLoss` and `HSPDoubleSphereLoss` now dispatch on `HSP.ndim` — scalar path for `minimize`, batch path `(n_params, S) → (S,)` for DE. Enables `vectorized=True` in scipy's `differential_evolution`, replacing ~S Python function calls per generation with one `NumPy` operation.
- Tightened DE defaults: `de_maxiter `reduced from 2000 to 1000; `de_updating` default changed to `'deferred'` (required by scipy when `vectorized=True`).

## Files changed

  - hspipy/core/hsp_estimator.py
  - hspipy/core/loss.py